### PR TITLE
Add CLI for blocking students

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# SISTEMA-GERAL Backend
+
+Este repositório concentra o backend da aplicação do CED Brasília.
+
+## Executando localmente
+
+Instale as dependências e inicie o servidor FastAPI:
+
+```bash
+pip install -r requirements.txt
+python main.py
+```
+
+A API ficará disponível em `http://localhost:8000` (ou na porta definida pela variável `PORT`).
+
+## Principais rotas
+
+- `POST /matricular`: realiza matrícula de alunos.
+- `GET  /alunos`: lista todos os alunos da unidade.
+- `POST /bloquear/{id_aluno}?status=0|1`: define o bloqueio de um aluno.
+
+Um status `0` equivale a **desbloqueado**, enquanto `1` indica **bloqueado**. Exemplo:
+
+```bash
+curl -X POST "https://api.cedbrasilia.com.br/bloquear/123?status=1"
+```
+
+## Utilitário de linha de comando
+
+Alguns módulos podem ser executados diretamente. Por exemplo, para alterar o bloqueio de um aluno:
+
+```bash
+python bloquear.py 123 0
+```
+
+Isso envia a solicitação correspondente à API configurada por meio das variáveis de ambiente `OM_BASE`, `BASIC_B64` e `UNIDADE_ID`.
+

--- a/bloquear.py
+++ b/bloquear.py
@@ -49,3 +49,24 @@ def bloquear(id_aluno: str, status: int):
         return {"message": "Status atualizado"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+if __name__ == "__main__":  # pragma: no cover - utilitário de linha de comando
+    import sys
+
+    if len(sys.argv) != 3:
+        print("Uso: python bloquear.py <id_aluno> <status (0|1)>")
+        sys.exit(1)
+
+    aluno_id = sys.argv[1]
+    try:
+        status_int = int(sys.argv[2])
+    except ValueError:
+        print("Status deve ser 0 ou 1")
+        sys.exit(1)
+
+    try:
+        _alterar_bloqueio(aluno_id, status_int)
+        print("Status atualizado")
+    except Exception as exc:  # pragma: no cover - saída simples
+        print(f"Erro ao definir bloqueio: {exc}")


### PR DESCRIPTION
## Summary
- add README for backend usage
- extend `bloquear.py` with a small CLI helper so it can be run directly

## Testing
- `pytest -q`
- `python -m py_compile bloquear.py`

------
https://chatgpt.com/codex/tasks/task_e_684894ac2fc48326aee86e2dc9e0a02e