### PR TITLE
Corrige rota /cursos sem barra final

### DIFF
--- a/cursos.py
+++ b/cursos.py
@@ -19,6 +19,8 @@ CURSOS_OM: Dict[str, List[int]] = {
     "None": [129, 198, 156, 154],
 }
 
+# Aceita /cursos e /cursos/
+@router.get("", summary="Lista de cursos disponíveis")
 @router.get("/", summary="Lista de cursos disponíveis")
 async def listar_cursos():
     """Retorna o mapeamento de cursos do CED para as disciplinas da OM."""


### PR DESCRIPTION
## Resumo
- aceita requests em `/cursos` sem precisar de redirecionamento

## Testes
- `python -m py_compile SISTEMA-GERAL/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684a191636488326b4200fb071b4fef6