### PR TITLE
Add login API for OM token redirect

### DIFF
--- a/login.py
+++ b/login.py
@@ -1,0 +1,38 @@
+import os
+import requests
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+
+router = APIRouter()
+
+OM_BASE = os.getenv("OM_BASE")  # exemplo: https://meuappdecursos.com.br/ws/v2
+BASIC_B64 = os.getenv("BASIC_B64")
+
+
+class LoginData(BaseModel):
+    usuario: str
+    senha: str
+
+
+@router.post("/", summary="Realiza login do aluno na OM e redireciona para o EAD")
+def login(dados: LoginData):
+    """Recebe usuário e senha, obtém token da OM e redireciona para o EAD."""
+    if not OM_BASE or not BASIC_B64:
+        raise HTTPException(500, detail="Variáveis de ambiente OM não configuradas.")
+
+    url = f"{OM_BASE}/alunos/token"
+    headers = {"Authorization": f"Basic {BASIC_B64}"}
+    payload = {"usuario": dados.usuario, "senha": dados.senha}
+
+    try:
+        r = requests.post(url, headers=headers, data=payload, timeout=8)
+    except requests.RequestException as e:
+        raise HTTPException(500, detail=f"Erro de conexão: {str(e)}")
+
+    if r.ok and r.json().get("status") == "true":
+        token = r.json()["data"]["token"]
+        redirect_url = f"https://ead.cedbrasilia.com.br/index.php?pag=entrar&token={token}"
+        return RedirectResponse(url=redirect_url, status_code=302)
+
+    raise HTTPException(401, detail="Usuário ou senha inválidos.")

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ import deletar
 import kiwify
 import matricularasaas
 import bloquear
+import login
 
 
 # ──────────────────────────────────────────────────────────
@@ -52,6 +53,7 @@ app.include_router(kiwify.router,     prefix="/kiwify", tags=["Kiwify"])
 app.include_router(matricularasaas.router,  tags=["Matrícula Assas"])
 app.include_router(deletar.router,    tags=["Excluir Aluno"])
 app.include_router(bloquear.router,   tags=["Bloqueio"])
+app.include_router(login.router,      prefix="/login",     tags=["Login"])
 
 
 


### PR DESCRIPTION
## Summary
- implement new `login.py` with FastAPI router to authenticate against OM API and redirect user to EAD
- register login router in `main.py`

## Testing
- `python -m py_compile login.py`
- `python -m py_compile main.py`
- `python -m pip check`


------
https://chatgpt.com/codex/tasks/task_e_684a63c871e083269aa8022c5257890f