### PR TITLE
Adicionar padronização do número em envios via WhatsApp

### DIFF
--- a/app/whatsapp.py
+++ b/app/whatsapp.py
@@ -3,6 +3,7 @@ import logging
 import phonenumbers
 from fastapi import APIRouter, HTTPException, BackgroundTasks
 from pydantic import BaseModel
+from utils import formatar_numero_whatsapp
 try:
     from wppconnect import WppConnect
 except Exception:  # pragma: no cover - lib opcional
@@ -43,9 +44,9 @@ async def send(msg: Msg, bg: BackgroundTasks):
     if not wpp:
         raise HTTPException(501, "Biblioteca wppconnect indisponível")
 
-    # Validação E.164
+    numero_formatado = "+" + formatar_numero_whatsapp(msg.numero)
     try:
-        p = phonenumbers.parse(msg.numero, None)
+        p = phonenumbers.parse(numero_formatado, None)
         if not phonenumbers.is_valid_number(p):
             raise ValueError()
     except Exception:
@@ -53,7 +54,7 @@ async def send(msg: Msg, bg: BackgroundTasks):
     if STATUS["state"] != "ready":
         raise HTTPException(503, "Sessão WhatsApp ainda não conectada")
 
-    chat_id = msg.numero.lstrip("+") + "@c.us"
+    chat_id = numero_formatado.lstrip("+") + "@c.us"
 
     def _worker():
         try:

--- a/kiwify.py
+++ b/kiwify.py
@@ -4,6 +4,7 @@ import unicodedata
 import difflib
 import datetime
 import json
+from utils import formatar_numero_whatsapp
 from fastapi import APIRouter, Request, Depends, HTTPException
 from fastapi.responses import JSONResponse
 import gspread
@@ -38,7 +39,7 @@ def enviar_log_whatsapp(mensagem: str) -> None:
     """Envia mensagem de log via WhatsApp, ignorando tokens renovados."""
     if "Token de unidade atualizado" in mensagem:
         return
-    numero = "".join(filter(str.isdigit, WHATSAPP_LOG_NUM))
+    numero = formatar_numero_whatsapp(WHATSAPP_LOG_NUM)
     if not numero:
         return
     try:
@@ -123,7 +124,7 @@ def buscar_aluno_por_cpf(cpf: str) -> str | None:
 def enviar_whatsapp_chatpro(nome: str, celular: str, plano: str, cpf: str, senha_padrao: str = "1234567") -> None:
     """Envia uma mensagem de boas-vindas via WhatsApp."""
 
-    numero_telefone = "".join(filter(str.isdigit, celular))
+    numero_telefone = formatar_numero_whatsapp(celular)
 
     mensagem = (
         f"👋 Olá, {nome}!\n\n"

--- a/matricular.py
+++ b/matricular.py
@@ -3,6 +3,7 @@ import threading
 from typing import List, Tuple, Optional
 import requests
 from fastapi import APIRouter, HTTPException
+from utils import formatar_numero_whatsapp
 from datetime import datetime
 from cursos import CURSOS_OM  # Importa o dicionário de mapeamento
 
@@ -214,8 +215,8 @@ def _send_whatsapp_chatpro(
     """
     # Novo endpoint não requer token ou configuração adicional
 
-    # Garante que o número seja somente dígitos (sem parênteses, espaços ou traços)
-    numero_telefone = "".join(filter(str.isdigit, whatsapp))
+    # Formata e adiciona o DDI brasileiro caso ausente
+    numero_telefone = formatar_numero_whatsapp(whatsapp)
 
     # Monta a mensagem com emojis e credenciais
     cursos_texto = "\n".join(f"• {c}" for c in cursos_nomes) if cursos_nomes else "Nenhum curso específico."
@@ -251,7 +252,7 @@ def _send_whatsapp_log(mensagem: str) -> None:
     """Envia mensagem de log para o WhatsApp, exceto para renovação de token."""
     if "Token de unidade atualizado" in mensagem:
         return
-    numero = "".join(filter(str.isdigit, WHATSAPP_LOG_NUM))
+    numero = formatar_numero_whatsapp(WHATSAPP_LOG_NUM)
     if not numero:
         return
     try:
@@ -287,7 +288,7 @@ def _send_discord_log(
         "✅ MATRÍCULA REALIZADA COM SUCESSO\n\n"
         f"👤 Nome: {nome}\n"
         f"📄 CPF: {cpf}\n"
-        f"📱 Celular: +{whatsapp}\n"
+        f"📱 Celular: +{formatar_numero_whatsapp(whatsapp)}\n"
         f"🎓 Cursos: {cursos_ids}"
     )
 

--- a/matricularasaas.py
+++ b/matricularasaas.py
@@ -1,6 +1,7 @@
 import os
 from fastapi import Request, HTTPException, APIRouter
 import requests
+from utils import formatar_numero_whatsapp
 
 # CHAMADA ROUTER 
 
@@ -56,7 +57,7 @@ async def asaas_webhook(req: Request):
         requests.get(
             WHATSAPP_URL,
             params={
-                "para": phone,
+                "para": formatar_numero_whatsapp(phone),
                 "mensagem": f"Olá {nome}, sua matrícula foi confirmada com sucesso!"
             },
             timeout=10,

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,9 @@
+# Funções utilitárias para o sistema.
+
+
+def formatar_numero_whatsapp(numero: str) -> str:
+    """Remove caracteres não numéricos e garante prefixo '55'."""
+    digitos = "".join(filter(str.isdigit, numero or ""))
+    if not digitos.startswith("55"):
+        digitos = "55" + digitos
+    return digitos


### PR DESCRIPTION
## Summary
- adicionar utilitário para formatar números de WhatsApp
- aplicar formatação antes de enviar mensagens nos módulos `kiwify`, `matricular`, `matricularasaas` e rota `/whatsapp`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f63b2ccbc8326b29f2478ebef69a4