### PR TITLE
Implementa formatação de número para WhatsApp

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -2,8 +2,18 @@
 
 
 def formatar_numero_whatsapp(numero: str) -> str:
-    """Remove caracteres não numéricos e garante prefixo '55'."""
+    """Formata número de WhatsApp removendo o '9' e garantindo prefixo '55'."""
+
+    # Extrai apenas os dígitos
     digitos = "".join(filter(str.isdigit, numero or ""))
-    if not digitos.startswith("55"):
-        digitos = "55" + digitos
-    return digitos
+
+    # Remove prefixo Brasil caso já esteja presente
+    if digitos.startswith("55"):
+        digitos = digitos[2:]
+
+    # Remove o nono dígito (após o DDD) se existir
+    if len(digitos) == 11 and digitos[2] == "9":
+        digitos = digitos[:2] + digitos[3:]
+
+    # Garante o prefixo brasileiro
+    return "55" + digitos


### PR DESCRIPTION
## Descrição
- remove o nono dígito do celular quando presente
- garante o prefixo brasileiro `55` antes de enviar

## Testes
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python main.py` (servidor inicializa e encerra normalmente)


------
https://chatgpt.com/codex/tasks/task_e_684f77a833f883269c92d52afecf054f