### PR TITLE
Fix WhatsApp checkout message

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -2,18 +2,14 @@
 
 
 def formatar_numero_whatsapp(numero: str) -> str:
-    """Formata número de WhatsApp removendo o '9' e garantindo prefixo '55'."""
+    """Formata número de WhatsApp garantindo o prefixo `55`."""
 
-    # Extrai apenas os dígitos
+    # Extrai apenas os dígitos informados
     digitos = "".join(filter(str.isdigit, numero or ""))
 
     # Remove prefixo Brasil caso já esteja presente
     if digitos.startswith("55"):
         digitos = digitos[2:]
 
-    # Remove o nono dígito (após o DDD) se existir
-    if len(digitos) == 11 and digitos[2] == "9":
-        digitos = digitos[:2] + digitos[3:]
-
-    # Garante o prefixo brasileiro
+    # Mantém o nono dígito, compatível com celulares atuais
     return "55" + digitos


### PR DESCRIPTION
## Summary
- keep the ninth digit when formatting WhatsApp numbers

## Testing
- `python -m py_compile asaas.py matricular.py kiwify.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684fee37630483268039a383477888d2