### PR TITLE
Atualiza formatação do número de WhatsApp

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -2,7 +2,12 @@
 
 
 def formatar_numero_whatsapp(numero: str) -> str:
-    """Formata número de WhatsApp garantindo o prefixo `55`."""
+    """Formata o telefone para envio via WhatsApp.
+
+    - Garante o prefixo brasileiro ``55``.
+    - Remove quaisquer caracteres não numéricos.
+    - Remove o nono dígito logo após o DDD, caso presente.
+    """
 
     # Extrai apenas os dígitos informados
     digitos = "".join(filter(str.isdigit, numero or ""))
@@ -11,5 +16,8 @@ def formatar_numero_whatsapp(numero: str) -> str:
     if digitos.startswith("55"):
         digitos = digitos[2:]
 
-    # Mantém o nono dígito, compatível com celulares atuais
+    # Remove o nono dígito (ex.: 61912345678 -> 6112345678)
+    if len(digitos) >= 11 and digitos[2] == "9":
+        digitos = digitos[:2] + digitos[3:]
+
     return "55" + digitos


### PR DESCRIPTION
## Notes
- Ajustado `formatar_numero_whatsapp` para remover o nono dígito quando o número é precedido pelo DDD e será enviado com o prefixo `55`.

## Summary
- padroniza formatação de telefone removendo o nono dígito logo após o DDD


------
https://chatgpt.com/codex/tasks/task_e_684ff200252083269e43402ecf06bec7