### PR TITLE
Fix webhook invoice link

### DIFF
--- a/asaas.py
+++ b/asaas.py
@@ -249,6 +249,22 @@ async def webhook(req: Request):
         or payment.get("bankSlipUrl")
         or payment.get("transactionReceiptUrl")
     )
+    if not fatura_url and payment.get("id"):
+        try:
+            resp = requests.get(
+                f"{ASAAS_BASE_URL}/payments/{payment['id']}",
+                headers=_headers(),
+                timeout=10,
+            )
+            if resp.ok:
+                data = resp.json()
+                fatura_url = (
+                    data.get("invoiceUrl")
+                    or data.get("bankSlipUrl")
+                    or data.get("transactionReceiptUrl")
+                )
+        except requests.RequestException:
+            logger.exception("Erro ao buscar detalhes do pagamento %s", payment.get("id"))
     customer_id = payment.get("customer") or evt.get("customer")
     if not customer_id:
         return {"status": "ignored"}


### PR DESCRIPTION
## Summary
- fetch payment details in webhook when invoice link isn't included in event

## Testing
- `python -m py_compile SISTEMA-GERAL/asaas.py`


------
https://chatgpt.com/codex/tasks/task_e_684ffac55c988326b5aae4cd682e862e