### PR TITLE
Implementa vencimento um mês após compra

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ O retorno inclui o `subscription` gerado pelo ASAAS e o link para pagamento.
 ### Assinatura automática após compra na Kiwify
 
 Quando um pedido aprovado é recebido pelo webhook da Kiwify, o aluno é cadastrado
-no ASAAS como **assinatura**. A data de vencimento inicial é sempre 30 dias após
-o pagamento na Kiwify. O valor da assinatura pode ser enviado no payload ou,
+no ASAAS como **assinatura**. A data de vencimento inicial é sempre no mesmo dia
+do mês seguinte ao pagamento realizado na Kiwify. O valor da assinatura pode ser enviado no payload ou,
 caso não informado, será utilizado o valor definido na variável de ambiente
 `ASSINATURA_VALOR_PADRAO` (padrão `0`).
 

--- a/asaas.py
+++ b/asaas.py
@@ -1,6 +1,7 @@
 import os
 import logging
 from datetime import date
+from dateutil.relativedelta import relativedelta
 from typing import List
 
 import requests
@@ -228,7 +229,7 @@ def criar_assinatura_recorrente(dados: dict):
         "ASAAS_BILLING_TYPE", "UNDEFINED"
     )
     cycle = dados.get("ciclo") or dados.get("cycle") or "MONTHLY"
-    next_due = dados.get("dueDate") or date.today().isoformat()
+    next_due = dados.get("dueDate") or (date.today() + relativedelta(months=1)).isoformat()
     callback_url = os.getenv("ASAAS_CALLBACK_URL")
     redirect_url = os.getenv("ASAAS_REDIRECT_URL")
 

--- a/kiwify.py
+++ b/kiwify.py
@@ -3,6 +3,7 @@ import requests
 import unicodedata
 import difflib
 import datetime
+from dateutil.relativedelta import relativedelta
 import json
 import asaas
 from utils import formatar_numero_whatsapp
@@ -233,7 +234,9 @@ def adicionar_aluno_planilha(dados: dict) -> None:
         client = gspread.authorize(creds)
         sheet = client.open(GOOGLE_SHEET_NAME).sheet1
 
-        proxima_cobranca = (datetime.datetime.now() + datetime.timedelta(days=30)).strftime("%d/%m/%Y")
+        proxima_cobranca = (
+            datetime.datetime.now() + relativedelta(months=1)
+        ).strftime("%d/%m/%Y")
         linha_para_adicionar = [
             dados.get("nome"), dados.get("celular"), dados.get("email"), dados.get("cpf"),
             proxima_cobranca, dados.get("metodo_pagamento"), dados.get("plano_assinatura"),
@@ -322,7 +325,7 @@ async def _process_webhook(payload: dict):
             raise HTTPException(500, f"Falha ao matricular: {resp_matricula.text}")
 
         vencimento = (
-            datetime.datetime.now() + datetime.timedelta(days=30)
+            datetime.datetime.now() + relativedelta(months=1)
         ).strftime("%d/%m/%Y")
         enviar_whatsapp_chatpro(
             nome,
@@ -342,8 +345,7 @@ async def _process_webhook(payload: dict):
                     "descricao": plano_assinatura,
                     "cursos_ids": cursos_ids,
                     "dueDate": (
-                        datetime.datetime.now()
-                        + datetime.timedelta(days=30)
+                        datetime.datetime.now() + relativedelta(months=1)
                     ).strftime("%Y-%m-%d"),
                 }
             )

--- a/matricular.py
+++ b/matricular.py
@@ -4,7 +4,8 @@ from typing import List, Tuple, Optional
 import requests
 from fastapi import APIRouter, HTTPException
 from utils import formatar_numero_whatsapp
-from datetime import datetime, timedelta
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
 from cursos import CURSOS_OM, obter_nomes_por_ids  # Importa o dicionário de mapeamento e utilitário
 
 router = APIRouter()
@@ -402,7 +403,7 @@ async def realizar_matricula(dados: dict):
         )
 
         # 3) envia mensagem automática no WhatsApp via ChatPro (agora com login e senha)
-        venc = (datetime.now() + timedelta(days=30)).strftime("%d/%m/%Y")
+        venc = (datetime.now() + relativedelta(months=1)).strftime("%d/%m/%Y")
         _send_whatsapp_chatpro(nome, whatsapp, cursos_nomes, cpf, vencimento=venc)
 
         # 4) envia log para o Discord informando sucesso na matrícula

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ flask
 gspread
 google-auth-oauthlib
 phonenumbers
+python-dateutil


### PR DESCRIPTION
## Alterações
- Configura dependência `python-dateutil`.
- Ajusta cálculo do vencimento inicial das assinaturas para o mesmo dia do mês seguinte.
- Atualiza mensagens e planilhas com a nova lógica de data.
- Documentação atualizada.

## Testes
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68511a2c726c832680b1f4b6e27c2cc3