### PR TITLE
Implementa operações CRUD para assinantes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ A API ficará disponível em `http://localhost:8000` (ou na porta definida pela 
 - `POST /matricular`: realiza matrícula de alunos.
 - `GET  /alunos`: lista todos os alunos da unidade.
 - `POST /bloquear/{id_aluno}?status=0|1`: define o bloqueio de um aluno.
+- `GET  /assinantes`: lista assinaturas ativas.
+- `POST /assinantes`: cria uma assinatura no ASAAS.
+- `PUT  /assinantes/{id}`: altera dados da assinatura.
+- `DELETE /assinantes/{id}`: remove a assinatura.
 
 Um status `0` equivale a **desbloqueado**, enquanto `1` indica **bloqueado**. Exemplo:
 
@@ -96,4 +100,21 @@ gera a fatura no ASAAS e envia o link via WhatsApp para o aluno.
 
 1. O aluno é sempre cadastrado usando o **CPF informado** na compra.
 2. Pagamentos recorrentes não geram nova matrícula quando o CPF já existir na OM.
+
+## Gerenciamento de assinantes
+
+A rota `/assinantes` permite consultar e alterar assinaturas no ASAAS.
+
+### Exemplo de criação
+
+```bash
+POST /assinantes
+{
+  "nome": "João da Silva",
+  "cpf": "12345678909",
+  "whatsapp": "(61) 99999-9999",
+  "valor": 59.9,
+  "descricao": "Plano Mensal"
+}
+```
 

--- a/assinantes.py
+++ b/assinantes.py
@@ -1,6 +1,10 @@
 import os
+from datetime import date
 import requests
 from fastapi import APIRouter, HTTPException
+
+from asaas import _criar_ou_obter_cliente, _headers
+from utils import parse_valor
 
 router = APIRouter(prefix="/assinantes", tags=["Assinantes"])
 
@@ -61,3 +65,101 @@ def listar_assinantes():
         )
 
     return {"assinantes": assinantes}
+
+
+@router.post("/")
+def adicionar_assinante(dados: dict):
+    """Cria uma nova assinatura no ASAAS."""
+
+    nome = dados.get("nome")
+    cpf = dados.get("cpf")
+    phone = dados.get("whatsapp") or dados.get("phone")
+    valor = parse_valor(dados.get("valor"))
+    descricao = dados.get("descricao") or "Assinatura"
+    ciclo = dados.get("ciclo") or dados.get("cycle") or "MONTHLY"
+    vencimento = dados.get("vencimento") or dados.get("nextDueDate") or date.today().isoformat()
+    billing = dados.get("billingType") or os.getenv("ASAAS_BILLING_TYPE", "UNDEFINED")
+
+    if not nome or not cpf or not phone or valor is None:
+        raise HTTPException(400, "Campos obrigatórios ausentes")
+    if valor <= 0:
+        raise HTTPException(400, "Valor inválido")
+
+    cid = _criar_ou_obter_cliente(nome, cpf, phone)
+
+    payload = {
+        "customer": cid,
+        "billingType": billing,
+        "value": valor,
+        "cycle": ciclo,
+        "nextDueDate": vencimento,
+        "description": descricao,
+    }
+
+    try:
+        resp = requests.post(
+            f"{ASAAS_BASE_URL}/subscriptions",
+            json=payload,
+            headers=_headers(),
+            timeout=10,
+        )
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        raise HTTPException(502, f"Erro ao criar assinatura: {e}")
+
+    return resp.json()
+
+
+@router.put("/{assinatura_id}")
+def alterar_assinante(assinatura_id: str, dados: dict):
+    """Altera dados de uma assinatura existente."""
+
+    payload = {}
+    if "valor" in dados:
+        val = parse_valor(dados.get("valor"))
+        if val is None or val <= 0:
+            raise HTTPException(400, "Valor inválido")
+        payload["value"] = val
+    if "descricao" in dados:
+        payload["description"] = dados["descricao"]
+    if "ciclo" in dados or "cycle" in dados:
+        payload["cycle"] = dados.get("ciclo") or dados.get("cycle")
+    if "vencimento" in dados or "nextDueDate" in dados:
+        payload["nextDueDate"] = dados.get("vencimento") or dados.get("nextDueDate")
+    if "billingType" in dados:
+        payload["billingType"] = dados["billingType"]
+
+    if not payload:
+        raise HTTPException(400, "Nenhum campo para atualização informado")
+
+    try:
+        resp = requests.put(
+            f"{ASAAS_BASE_URL}/subscriptions/{assinatura_id}",
+            json=payload,
+            headers=_headers(),
+            timeout=10,
+        )
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        raise HTTPException(502, f"Erro ao atualizar assinatura: {e}")
+
+    if resp.status_code == 200:
+        return resp.json()
+    return {"status": "atualizado"}
+
+
+@router.delete("/{assinatura_id}")
+def remover_assinante(assinatura_id: str):
+    """Remove uma assinatura do ASAAS."""
+
+    try:
+        resp = requests.delete(
+            f"{ASAAS_BASE_URL}/subscriptions/{assinatura_id}",
+            headers=_headers(),
+            timeout=10,
+        )
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        raise HTTPException(502, f"Erro ao remover assinatura: {e}")
+
+    return {"status": "removido"}


### PR DESCRIPTION
## Resumo
- adiciona rotas POST/PUT/DELETE para `/assinantes`
- atualiza documentação no README com novas rotas

## Testes
- `python -m py_compile assinantes.py`


------
https://chatgpt.com/codex/tasks/task_e_685133b1475883268f0dab33d511bf62