### PR TITLE
Add static site endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A API ficará disponível em `http://localhost:8000` (ou na porta definida pela 
 - `POST /assinantes`: cria uma assinatura no ASAAS.
 - `PUT  /assinantes/{id}`: altera dados da assinatura.
 - `DELETE /assinantes/{id}`: remove a assinatura.
+- `GET  /site`: exibe uma página de teste.
 
 Um status `0` equivale a **desbloqueado**, enquanto `1` indica **bloqueado**. Exemplo:
 

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ import cobrar
 import bloquear
 import login
 import mensagemdecobranca
+import site_page
 from app import whatsapp
 
 
@@ -64,6 +65,7 @@ app.include_router(bloquear.router,   tags=["Bloqueio"])
 app.include_router(login.router,      prefix="/login",     tags=["Login"])
 app.include_router(whatsapp.router)
 app.include_router(mensagemdecobranca.router)
+app.include_router(site_page.router)
 
 
 

--- a/site.html
+++ b/site.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>teste</title>
+</head>
+<body>
+    <h1> TESTANDO 123</h1>
+</body>
+</html>

--- a/site_page.py
+++ b/site_page.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+import os
+
+router = APIRouter()
+
+SITE_FILE = os.path.join(os.path.dirname(__file__), "site.html")
+
+
+@router.get("/site", response_class=HTMLResponse, include_in_schema=False)
+async def get_site():
+    """Retorna a página de teste."""
+    try:
+        with open(SITE_FILE, "r", encoding="utf-8") as f:
+            content = f.read()
+    except FileNotFoundError:
+        return HTMLResponse("Site não encontrado", status_code=404)
+    return HTMLResponse(content)


### PR DESCRIPTION
## Summary
- serve a simple HTML file at `/site`
- register the new router in the FastAPI app
- document the new endpoint in the README

## Testing
- `python -m py_compile $(find . -maxdepth 1 -name '*.py' -print)`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685167dd68ac8326bf74385a3b28174c